### PR TITLE
handle field query returns logical

### DIFF
--- a/R/RomProperty.R
+++ b/R/RomProperty.R
@@ -335,7 +335,7 @@ RomProperty <- R6Class(
           matrix_check <- self$datasource$get(
             'field_data_field_dh_matrix','revision_id',list(revision_id = self$vid)
           )
-          if (nrow(matrix_check) == 0) {
+          if (is.logical(matrix_check) || (nrow(matrix_check) == 0)) {
             pk <- NA # forces insert
           }
           self$matrix_revision_id = self$datasource$post(


### PR DESCRIPTION
@COBrogan and now a 3rd tweak, as there was a case when adding a brand new data matrix where the routine did not expect ODBC to return FALSE, and it crashed and returned no property, even though the property itself was created, it just didn't have the matrix field populated.  This handles that situation now.