### PR TITLE
fixed handling of returned values from odbc in variable def class

### DIFF
--- a/R/RomVariableDefinition.R
+++ b/R/RomVariableDefinition.R
@@ -60,11 +60,9 @@ RomVariableDefinition <- R6Class(
     #' @return NULL
     from_list = function(config) {
       for (i in names(config)) {
-        if (i %in% names(self)) {
-          if (typeof(self[[i]]) != 'closure') {
-            # this is not a function, so we can set it
-            self[[i]] = config[[i]]
-          }
+        if (typeof(self[[i]]) != 'closure') {
+          # this is not a function, so we can set it
+          self[[i]] = config[[i]]
         }
       }
     },


### PR DESCRIPTION
@COBrogan this allows us to grab individual vardefs which *I think* weren't actually functioning before.  We had a workaround (or a pre-existing method) in the `RomEntity$get_vardef()`, so, eventually we can streamline that to be a simple `self$vardef = RomVariableDefinition()` command -- after this code is fully tested for a while.