### PR TITLE
se the hydrotools version of is.empty and populate the parent_id attr…

### DIFF
--- a/R/RomFeature.R
+++ b/R/RomFeature.R
@@ -117,6 +117,8 @@ RomFeature <- R6Class(
           self$geom = as.character(config$dh_geofield)
         } else if (i == "nextdown_id") {
           self$nextdown_id = as.integer(config$nextdown_id)
+        } else if (i == "parent_id") {
+          self$parent_id = as.integer(config$parent_id)
         }
       }
     },

--- a/R/cia_utils.R
+++ b/R/cia_utils.R
@@ -600,7 +600,7 @@ fn_downstream <- function(riv.seg, AllSegList) {
     Upstream <- which(as.character(ModelSegments$Downstream)==as.character(ModelSegments$RiverSeg[k]))
     NumUp <- ModelSegments$RiverSeg[Upstream]
     ModelSegments[k,6]<- paste(NumUp, collapse = '+')
-    if (is.empty(ModelSegments[k,6])==TRUE){
+    if (hydrotools::is.empty(ModelSegments[k,6])==TRUE){
       ModelSegments[k,6]<- 'NA'
     } 
     k<-k+1


### PR DESCRIPTION
…ibute of RomFeature classes

@COBrogan @BrendanBrogan -- this is actually fairly important update.  The "parent_id" property of RomFeatures, i.e. for an intake, the parent_id should point to its facility, was not being populated, even though that information WAS in the dh_feature_fielded SQL view that is loaded from ODBC.  Now this works, and makes tracing things a lot easier.  This also exposes the local hydrotools `is.empty` function, though this might be superfluous?